### PR TITLE
Made comments and punctuations distinguishable

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -86,7 +86,7 @@
 # "string.special.url" = ""
 # "string.special.symbol" = ""
 
-"comment" = { fg = "muted", modifiers = ["italic"]}
+"comment" = { fg = "muted_low", modifiers = ["italic"]}
 # "comment.line" = ""
 # "comment.block" = ""
 # "comment.block.documenation" = ""
@@ -99,7 +99,7 @@
 
 "label" = "foam"
 
-"punctuation" = "subtle"
+"punctuation" = "subtle_high"
 # "punctuation.delimiter" = ""
 # "punctuation.bracket" = ""
 # "punctuation.special" = ""
@@ -170,7 +170,9 @@ base           = "#191724"
 surface        = "#1f1d2e" 
 overlay        = "#26233a"
 muted          = "#6e6a86"
+muted_low      = "#58556d"
 subtle         = "#908caa"
+subtle_high    = "#a09dc5"
 text           = "#e0def4"
 love           = "#eb6f92"
 love_10        = "#311f30"


### PR DESCRIPTION
It was difficult to differentiate comments and punctuations especially in block-structured languages like C which 
uses punctuations a lot to define scopes

<img width="386" alt="Screenshot 2023-05-03 at 6 08 10 PM" src="https://user-images.githubusercontent.com/88179338/235922503-61217b51-9d55-4205-9d2e-8ce17c9741c9.png">
Reduced the contrast of comments and increased that of punctuation very slightly just enough to differentiate them
without changing the core color scheme of this beautiful theme :)

<img width="386" alt="Screenshot 2023-05-03 at 6 07 55 PM" src="https://user-images.githubusercontent.com/88179338/235922512-cd85788f-650e-4d70-a47c-5356698a11f5.png">