### PR TITLE
Improve readability of Markup link text

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -151,7 +151,7 @@
 "markup.link" = "iris"
 "markup.link.url" = { fg = "iris", underline = { color = "iris", style = "line" } }
 "markup.link.label" = "subtle"
-"markup.link.text" = "text"
+"markup.link.text" = "foam"
 "markup.quote" = "subtle"
 "markup.raw" = "subtle"
 # "markup.raw.inline" = {}


### PR DESCRIPTION
fixes #9 (not on Neovim repo, only Helix)

I chose `foam` as color for link text since it is the default convention for websites.
I tested it and it has this effect on large amount of text:

![image](https://github.com/rose-pine/helix/assets/73542945/4d46069b-3d22-4f63-82e3-8a35b71fab1b)

If another color is preferred let me know!