### PR TITLE
Make inline and block-code gold

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -151,7 +151,7 @@
 "markup.link" = "iris"
 "markup.link.url" = { fg = "iris", underline = { color = "iris", style = "line" } }
 "markup.link.label" = "subtle"
-"markup.link.text" = "text"
+"markup.link.text" = "foam"
 "markup.quote" = "subtle"
 "markup.raw" = "subtle"
 # "markup.raw.inline" = {}

--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -154,10 +154,10 @@
 "markup.link.text" = "foam"
 "markup.quote" = "subtle"
 "markup.raw" = "subtle"
-# "markup.raw.inline" = {}
+"markup.raw.inline" = "gold"
 # "markup.raw.inline.completion" = {}
 # "markup.raw.inline.hover" = {}
-# "markup.raw.block" = {}
+"markup.raw.block" = "gold"
 # "markup.normal" = ""
 # "markup.normal.completion" = ""
 # "markup.normal.hover" = ""


### PR DESCRIPTION
Currently inline and block-codes  are muted (or subtle i can't really tell the difference), which is the color of content that should be ignored (according to the Rose Pine website).

I think highlighting this code instead of muting it improves the readability and recognition of special-treated-text.
I chose `gold` because it is also the color of strings (and generic values), and JavaScript template literals are also gold.

Edit: I see in the Files changed that my previous contribution is reapplied in this PR??? I probably did something wrong with syncing forks there but I don't think it can cause any harm.