### PR TITLE
Add pickers header styling

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -30,6 +30,8 @@
 "ui.popup" = { bg = "surface" }
 "ui.popup.info" = { bg = "surface" }
 
+"ui.picker.header" = { fg = "iris", modifiers = ["bold"] }
+
 "ui.window" = { fg = "overlay", bg = "base" }
 "ui.help" = { fg = "subtle", bg = "overlay" }
 


### PR DESCRIPTION
This PR adds styling for the headers of the soon-to-be merged (hopefully) new pickers. I took the styling of the first markdown heading.

As it is, it’s not very discernible in my opinion, however I don’t think it will be very problematic as after some time the user will get used to it being on the first line and the styling is just a little plus. It will not be as essential to discern it as some piece of code, for example.

I tried adding underline, but then it’s a bit less readable (maybe it’s just my font that’s very narrow). What are your thoughts? Would another colour or some text styling be better suited?

## Result

|PR|With underline|
|----|---------------------|
|![image](https://github.com/rose-pine/helix/assets/58810330/673dab62-ce7e-40f7-b95e-ccd4e2f65a5f)|![image](https://github.com/rose-pine/helix/assets/58810330/07288087-fb92-4c55-aa54-4674354e9cea)|

