### PR TITLE
Add string symbol color

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -89,7 +89,7 @@
 # "string.special" = ""
 # "string.special.path" = ""
 # "string.special.url" = ""
-# "string.special.symbol" = ""
+"string.special.symbol" = "iris"
 
 "comment" = { fg = "muted", modifiers = ["italic"] }
 # "comment.line" = ""


### PR DESCRIPTION
This PR adds the default string symbol color, for languages like ruby that support it.

### Rose Pine
![image](https://github.com/user-attachments/assets/e587cfa2-d7fa-47ac-8569-1c31f1d75e8a)
### Rose Pine Dawn
![image](https://github.com/user-attachments/assets/bbb4a143-c696-424e-a84a-6268851aa28a)
### Rose Pine Moon
![image](https://github.com/user-attachments/assets/7c742753-63dd-4fa3-9944-a71d269d5554)
