### PR TITLE
Change highlight colour to be more visible

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -49,8 +49,7 @@
 "ui.menu.selected" = { fg = "text" }
 "ui.menu.scroll" = { fg = "muted", bg = "highlight_med" }
 
-"ui.selection" = { bg = "overlay" }
-"ui.selection.primary" = { bg = "highlight_med" }
+"ui.selection" = { fg = "base", bg = "iris" }
 
 "ui.cursorline.primary" = { bg = "highlight_low" }
 "ui.cursorline.secondary" = { bg = "surface" }


### PR DESCRIPTION
The highlight colour currently is hard to see on some text.

This PR changes the background colour and foreground colour of highlights so it should standout no matter the context (surrounding colours) of the highlighted area