### PR TITLE
Fix `ui.background` fg color inheriting from terminal

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -27,8 +27,8 @@
 "ui.statusline.select" = { fg = "iris", bg = "iris_10" }
 # "ui.statusline.separator" = {}
 
-"ui.popup" = { bg = "surface" }
-"ui.popup.info" = { bg = "surface" }
+"ui.popup" = { fg = "text", bg = "surface" }
+"ui.popup.info" = { fg = "text", bg = "surface" }
 
 "ui.picker.header" = { fg = "iris", modifiers = ["bold"] }
 

--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -4,7 +4,7 @@
 #   Please submit changes to https://github.com/rose-pine/helix.
 #   The Rosé Pine team will update Helix, including you as a co-author.
 
-"ui.background" = { bg = "base" }
+"ui.background" = { fg = "text", bg = "base" }
 "ui.background.separator" = { bg = "base" }
 
 "ui.cursor" = { fg = "text", bg = "highlight_high" }

--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -28,7 +28,6 @@
 # "ui.statusline.separator" = {}
 
 "ui.popup" = { fg = "text", bg = "surface" }
-"ui.popup.info" = { fg = "text", bg = "surface" }
 
 "ui.picker.header" = { fg = "iris", modifiers = ["bold"] }
 


### PR DESCRIPTION
## Problem
The theme does not explicitly set the `ui.background` foreground color, which is used for picker borders, cursor color, and other elements. By default, Helix inherits this color from the terminal's ANSI 7 (White) color, which may be black in some terminal themes.

Screenshot of Alacritty with Acme theme:
<img width="1792" height="1400" alt="before" src="https://github.com/user-attachments/assets/18ba691f-b1b1-42ff-8610-7ef30dc3de1d" />


## Solution
Set it to the `text` color.

<img width="1792" height="1400" alt="after" src="https://github.com/user-attachments/assets/6d8342d9-7f0f-49d6-88ab-05b34dc057a0" />