### PR TITLE
Errors are hard to see when near Function.builtin

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -125,7 +125,7 @@
 "operator" = "subtle"
 
 "function" = "rose"         # maybe pine
-# "function.builtin" = ""
+"function.builtin" = { fg = "rose", modifiers = ["bold"] }
 # "function.method" = ""
 # "function.macro" = ""
 # "function.special" = ""

--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -125,7 +125,7 @@
 "operator" = "subtle"
 
 "function" = "rose"         # maybe pine
-"function.builtin" = "love"
+# "function.builtin" = ""
 # "function.method" = ""
 # "function.macro" = ""
 # "function.special" = ""


### PR DESCRIPTION
<img width="663" height="83" alt="image" src="https://github.com/user-attachments/assets/a6ea8261-8e60-4a35-b613-1bfee8eef56d" />
The function builtins and the errors being the same colour is incredibly annoying, neovim uses rose, I agree to use it here